### PR TITLE
Put routes in App component inside a Router element

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,26 +1,26 @@
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 
 import './App.css'
 import Layout from './components/Layout';
 import Posts from './components/Posts';
 import PostPage from './components/PostPage';
+import Header from './components/Header';
 
 function App() {
 
   return (
-    <Routes>
-      <Route path="/" element={<Layout />}>
-        <Route index element={<Posts />} />
-        <Route path='post'>
-          <Route index element={<PostPage />} />
-          {/* <Route path=':postId' element={<SinglePostPage />} />
-          <Route path='edit/:postId' element={<EditPostForm />} /> */}
-        </Route>
-
-        {/* catch all - maybe replace with 404 component  */}
-        {/* <Route path='*' element={<Navigate to='/' replace />} /> */}
-      </Route>
-    </Routes>
+      <Router>
+        <Routes>
+          <Route path="/" element={<Layout />}>
+            <Route index element={<Posts />} />
+            <Route path='post'>
+              <Route index element={<PostPage />} />
+              {/* <Route path=':postId' element={<SinglePostPage />} />
+              <Route path='edit/:postId' element={<EditPostForm />} /> */}
+            </Route>
+          </Route>
+        </Routes>
+      </Router>
   )
 }
 

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -5,12 +5,14 @@ const Header = () => {
   return (
     <header className='header'>
       <nav>
-        <li>
-          <Link to="/post">One post</Link>
-        </li>
-        <li>
-          <Link to="/">All posts</Link>
-        </li>
+        <ul>
+          <li>
+            <Link to="post">One post</Link>
+          </li>
+          <li>
+            <Link to="/">All posts</Link>
+          </li>
+        </ul>
       </nav>
     </header>
   )

--- a/frontend/src/components/Posts.jsx
+++ b/frontend/src/components/Posts.jsx
@@ -2,7 +2,9 @@ import React from 'react'
 
 const Posts = () => {
   return (
-    <div>all posts</div>
+    <div>
+      Ovo je komponenta za sve postove.
+    </div>
   )
 }
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -9,7 +9,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <Router>
       <Routes>
-        <Route path='*' element={<App />} />
+        <Route to='/' element={<App />} />
       </Routes>
     </Router>
     <App />


### PR DESCRIPTION
Closes #1 

This PR moves all routes in App component inside a Router element.

This is necessary because otherwise router won't work despite the fact that App component is a route inside main element.